### PR TITLE
trigger deploy action once main branch is pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,9 @@ jobs:
       - name: build static pages
         run: |
           make html SPHINXOPTS="-W --keep-going -n"
+      - name: deploy
+        if: github.ref == 'refs/heads/main'
+        env:
+          DEPLOY_HOOK_URL: ${{ secrets.DEPLOY_HOOK_URL }}
+        run: |
+          curl -sS --no-progress-memter "${DEPLOY_HOOK_URL}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,23 @@ on:
       - '.gitignore'
 
 jobs:
-  linux:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: install sphinx-build
         run: |
           pip3 install -U sphinx sphinx_copybutton
+
       - name: build static pages
         run: |
           make html SPHINXOPTS="-W --keep-going -n"
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: deploy
         if: github.ref == 'refs/heads/main'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Build and Deploy
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/README.txt'
+      - '.gitignore'
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: install sphinx-build
+        run: |
+          pip3 install -U sphinx sphinx_copybutton
+      - name: build static pages
+        run: |
+          make build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
           pip3 install -U sphinx sphinx_copybutton
       - name: build static pages
         run: |
-          make html SPHINXOPTS="-W"
+          make html SPHINXOPTS="-W --keep-going -n"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
           pip3 install -U sphinx sphinx_copybutton
       - name: build static pages
         run: |
-          make html
+          make html SPHINXOPTS="-W"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
           pip3 install -U sphinx sphinx_copybutton
       - name: build static pages
         run: |
-          make build
+          make html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     needs: build
     steps:
       - name: deploy
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           DEPLOY_HOOK_URL: ${{ secrets.DEPLOY_HOOK_URL }}
         run: |


### PR DESCRIPTION
This PR will try to build static HTML files when the main branch is pushed or a PR is opened.

When the main branch is pushed (including when a PR is merged), it will trigger a deploy action that calls a secret URL, and the server will automatically update the website. This secret URL is stored in `DEPLOY_HOOK_URL`, which can be set following this GitHub guide, https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository.

This would ensure the website is always kept update-to-date with the repo without using crontab or requiring human actions on the server.