### PR TITLE
uintptr_t does not maintain provenance information

### DIFF
--- a/pointerProvenanceIssue.c
+++ b/pointerProvenanceIssue.c
@@ -1,0 +1,27 @@
+
+#include<stdint.h>
+#include<stdio.h>
+
+int main () {
+
+int myArray[10];
+
+uintptr_t ptr =  (uintptr_t)&myArray[0]; //storing the address as uintptr_t
+
+//performing an invalid operation - accessing a non existent element 
+
+uintptr_r myPtr = ptr + sizeof(int)* 20; 
+
+//trying to accessing the memory using an invalid pointer 
+
+int myValue = *(int*)myPtr   // no memory safety checks 
+
+printf("invalid value : %d\n ",myValue);
+
+
+return 0;
+
+}  
+ 
+
+


### PR DESCRIPTION
You might use uintptr_t for pointer arithmetic in a standard C program, however, this might not maintain provenance information, making it prone to certain risks. 

A pointer address is stored as uintptr_t and perform an arithmetic operation that exceeds the bounds of the array. There is no runtime checks to prevent accessing invalid memory, and can lead to undefined behaviors or vulnerabilities 