### PR TITLE
 Facilitating Sweeping Revocation Technique 

### DIFF
--- a/CHERIProvenanceOfPointer.c
+++ b/CHERIProvenanceOfPointer.c
@@ -1,0 +1,22 @@
+#include<cheri.h>
+#include<stdio.h>
+
+int main(){
+
+int myArray[10];
+
+int *ptr = &myArray[0]; // storing the pointer as a capability
+
+//perform a capability safe operation  - accessing a valid element 
+
+int myValue = *ptr; 
+
+// access within bounds
+
+int *new_ptr = ptr + 5; 
+
+printf("valid value : %d\n", myValue); 
+
+return 0;
+
+}

--- a/CHERIcapabilitySweepingRevocation.c
+++ b/CHERIcapabilitySweepingRevocation.c
@@ -1,0 +1,47 @@
+#include<cheri.h>
+#include<stdio.h>
+int main() {
+
+//create a capability to a memory region 
+
+int data[10] = {0};
+
+cheri_object data_cap;
+
+data_cap = cheri_build_data_cap(data, sizeof(data), CHERI_PERM_LOAD|CHERI_PERM_STORE);
+
+//read and write access capability
+
+int* cap_ptr = cheri_cast(int*, data_cap);
+
+//read and write data 
+
+cap_ptr[0] = 42; 
+
+int value = cap_ptr[0];
+
+printf("initial value: %d\n", value);
+
+//let's simulate a security breach or a vulnerability detection 
+
+//decide to revoke or write access to the memory region 
+
+cheri_set_perms(&data_cap,CHERI_PERM_LOAD);//revoke write permissions
+
+//attempting to write after revoking triggers an exception 
+
+//uncommenting this line would trigger a capability violation exception 
+
+//cap_ptr[1]=99;
+
+//however,read access remains allowed 
+
+int read_value = cap_ptr[1];
+
+printf("read only value: %d\n", read_value);
+
+return 0; 
+
+
+}
+

--- a/pointerProvenanceIssue.c
+++ b/pointerProvenanceIssue.c
@@ -1,0 +1,27 @@
+
+#include<stdint.h>
+#include<stdio.h>
+
+int main () {
+
+int myArray[10];
+
+uintptr_t ptr =  (uintptr_t)&myArray[0]; //storing the address as uintptr_t
+
+//performing an invalid operation - accessing a non existent element 
+
+uintptr_r myPtr = ptr + sizeof(int)* 20; 
+
+//trying to accessing the memory using an invalid pointer 
+
+int myValue = *(int*)myPtr   // no memory safety checks 
+
+printf("invalid value : %d\n ",myValue);
+
+
+return 0;
+
+}  
+ 
+
+


### PR DESCRIPTION
A capability data_cap for memory region (an array data), with both load (read) and store (write) permissions. 
After some read and write operations, we could simulate some vulnerability detection. 
cheri_set_perms could be used to revoke for example, some permissions from data_cap. 
Therefore, after this revocation, any attempt to write to the memory by cap_ptr, would trigger a capability violation exception. However, read access remains allowed and can read from memory using same capability. 