### PR TITLE
Addressing insecure encapuslation 

### DIFF
--- a/CHERIProvenanceOfPointer.c
+++ b/CHERIProvenanceOfPointer.c
@@ -1,0 +1,22 @@
+#include<cheri.h>
+#include<stdio.h>
+
+int main(){
+
+int myArray[10];
+
+int *ptr = &myArray[0]; // storing the pointer as a capability
+
+//perform a capability safe operation  - accessing a valid element 
+
+int myValue = *ptr; 
+
+// access within bounds
+
+int *new_ptr = ptr + 5; 
+
+printf("valid value : %d\n", myValue); 
+
+return 0;
+
+}

--- a/CHERISecureEncapsulation.c
+++ b/CHERISecureEncapsulation.c
@@ -1,0 +1,52 @@
+#include<cheri.h>
+#include<stdio.h>
+#include<string.h>
+
+struct Student{
+
+char name[100]; 
+
+int age;
+
+};
+
+//component1
+
+void component1(void* studentCapability){
+
+struct Student* student = cheri_setbounds(studentCapability,sizeof(struct Student));
+
+strcpy(student->name,"Alice");
+
+student->age=20;
+
+}
+
+//component2
+
+void component2(void* studentCapability){
+
+struct Student* student = cheri_setbounds(studentCapability,sizeof(struct Student));
+
+printf("componet2 reads: Name: %s, Age: %d\n", student->name, student->age);
+
+}
+
+int main (){
+
+//memory allocation for the student data 
+
+struct Student sharedStudent;
+
+void* studentCapability = cheri_setbounds(&sharedStudent,sizeof(struct Student));
+
+//components use capability to access the shared student data
+
+component1(studentCapability);
+component2(studentCapability);
+
+return 0;
+
+}
+  
+

--- a/CHERIcapabilitySweepingRevocation.c
+++ b/CHERIcapabilitySweepingRevocation.c
@@ -1,0 +1,47 @@
+#include<cheri.h>
+#include<stdio.h>
+int main() {
+
+//create a capability to a memory region 
+
+int data[10] = {0};
+
+cheri_object data_cap;
+
+data_cap = cheri_build_data_cap(data, sizeof(data), CHERI_PERM_LOAD|CHERI_PERM_STORE);
+
+//read and write access capability
+
+int* cap_ptr = cheri_cast(int*, data_cap);
+
+//read and write data 
+
+cap_ptr[0] = 42; 
+
+int value = cap_ptr[0];
+
+printf("initial value: %d\n", value);
+
+//let's simulate a security breach or a vulnerability detection 
+
+//decide to revoke or write access to the memory region 
+
+cheri_set_perms(&data_cap,CHERI_PERM_LOAD);//revoke write permissions
+
+//attempting to write after revoking triggers an exception 
+
+//uncommenting this line would trigger a capability violation exception 
+
+//cap_ptr[1]=99;
+
+//however,read access remains allowed 
+
+int read_value = cap_ptr[1];
+
+printf("read only value: %d\n", read_value);
+
+return 0; 
+
+
+}
+

--- a/LackofSecureEncapsulationIssue.c
+++ b/LackofSecureEncapsulationIssue.c
@@ -1,0 +1,51 @@
+#include<stdio.h>
+#include<stdlib.h>
+
+struct Student {
+
+char name[100];
+
+int age;
+
+};
+
+struct Student* create_student(char name*, int age);
+
+struct Student* student = (struct Student*)malloc(sizeof(struct Student));
+
+if(student){
+
+strcpy(student->name, name);
+
+student->age = age; 
+
+}
+
+return student; 
+
+}
+
+int main() {
+
+struct Student* student1 = create_student("Alice", 20);
+
+struct Student* student2 = create_student("Bob", 22);
+
+//unintentional access to students data (no encapsulation)
+
+printf("student1: %s,%d\n", student2->name, student2->age);
+
+free(student1);
+free(student2);
+
+return 0;
+
+}
+
+
+
+
+
+
+
+

--- a/pointerProvenanceIssue.c
+++ b/pointerProvenanceIssue.c
@@ -1,0 +1,27 @@
+
+#include<stdint.h>
+#include<stdio.h>
+
+int main () {
+
+int myArray[10];
+
+uintptr_t ptr =  (uintptr_t)&myArray[0]; //storing the address as uintptr_t
+
+//performing an invalid operation - accessing a non existent element 
+
+uintptr_r myPtr = ptr + sizeof(int)* 20; 
+
+//trying to accessing the memory using an invalid pointer 
+
+int myValue = *(int*)myPtr   // no memory safety checks 
+
+printf("invalid value : %d\n ",myValue);
+
+
+return 0;
+
+}  
+ 
+
+


### PR DESCRIPTION
Each student record (or object) is encapsulated with a capability and ensuring that only code with valid capability can access data. 
cheri_malloc, cheri_free, prevents memory-related vulnerabilities found in the prior program, Therefore, risks associated with unintentional access of data are addressed. 