### PR TITLE
[ci] prevent deploy ci from running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: deploy
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           DEPLOY_HOOK_URL: ${{ secrets.DEPLOY_HOOK_URL }}
         run: |


### PR DESCRIPTION
This PR moved the `if`-clause to job-level so that GitHub Action can avoid to run the deploy job completely in a PR, which should save some time and resources. 

Before this PR, a separate runner will be allocated to run the deploy job in a PR, and then skip the deploy step. Now it should simply skip the whole thing when someone creates a PR.